### PR TITLE
update selenium driver to one used by grails-core master branch

### DIFF
--- a/hyphenated/build.gradle
+++ b/hyphenated/build.gradle
@@ -68,7 +68,8 @@ dependencies {
     testCompile "org.grails.plugins:geb"
 
     // Note: It is recommended to update to a more robust driver (Chrome, Firefox etc.)
-    testRuntime 'org.seleniumhq.selenium:selenium-htmlunit-driver:2.44.0'
+    testRuntime 'org.seleniumhq.selenium:selenium-htmlunit-driver:2.47.1'
+    testRuntime 'net.sourceforge.htmlunit:htmlunit:2.18'
 
     console "org.grails:grails-console"
 }


### PR DESCRIPTION
This also fixes the test failure 

```
org.openqa.selenium.WebDriverException: java.lang.IllegalArgumentException: Cannot locate declared field class org.apache.http.impl.client.HttpClientBuilder.sslcontext
```